### PR TITLE
IDPrinter for Undefined Terminal

### DIFF
--- a/pos-order-detail/pos-order-detail.page.ts
+++ b/pos-order-detail/pos-order-detail.page.ts
@@ -703,7 +703,7 @@ export class POSOrderDetailPage extends PageBase {
         let newKitchenList = [];
 
         this.printerTerminalProvider.search({ IDBranch: this.env.selectedBranch, IsDeleted: false, IsDisabled: false }).toPromise().then(async (results: any) => {
-            this.printerProvider.search({Id: (results[0].IDPrinter || 0 )}).toPromise().then(async (defaultPrinter: any) => {
+            this.printerProvider.search({Id: (results[0]?.IDPrinter || 0 )}).toPromise().then(async (defaultPrinter: any) => {
                 if (defaultPrinter && defaultPrinter.length != 0) {
                     defaultPrinter.forEach((p: any) => {
                         let Info = {


### PR DESCRIPTION
IDPrinter for Undefined Terminal
1. Tìm IDPrinter cho Terminal chi nhánh hiện tại.
2. Nếu không có IDPrinter, thì truyền vào ID là 0 cho printerProvider.Search. Nếu ID là 0 thì sẽ ra nguyên danh sách máy in chi nhánh hiện tại. Nếu truyền vào IDPrinter của terminal, ra duy nhất 1 printer.
3. So sánh, kiểm tra lần nữa. Nếu khớp thì sẽ in, nếu không thì sẽ báo kiểm tra thông tin printer.